### PR TITLE
Update extractSignature() to take a parameter which allows skipping Byte Range length verification

### DIFF
--- a/lib/certificateDetails.js
+++ b/lib/certificateDetails.js
@@ -32,9 +32,11 @@ const extractCertificatesDetails = (certs) => certs
     };
   });
 
-const getCertificatesInfoFromPDF = (pdf) => {
+const getCertificatesInfoFromPDF = (pdf, { skipByteRangeVerification } = {
+  skipByteRangeVerification: false,
+}) => {
   const pdfBuffer = preparePDF(pdf);
-  const { signature } = extractSignature(pdfBuffer);
+  const { signature } = extractSignature(pdfBuffer, skipByteRangeVerification);
   const { certificates } = getMessageFromSignature(signature);
   return extractCertificatesDetails(certificates);
 };

--- a/lib/helpers/extractSignature.js
+++ b/lib/helpers/extractSignature.js
@@ -25,7 +25,7 @@ const getByteRange = (pdfBuffer) => {
   };
 };
 
-const extractSignature = (pdf) => {
+const extractSignature = (pdf, skipByteRangeVerification = false) => {
   const pdfBuffer = preparePDF(pdf);
 
   const { byteRange } = getByteRange(pdfBuffer);
@@ -36,11 +36,13 @@ const extractSignature = (pdf) => {
     pdfBuffer.slice(byteRange[2], endOfByteRange),
   ]);
 
-  if (pdfBuffer.length > endOfByteRange) {
-    throw new VerifyPDFError(
-      'Failed byte range verification.',
-      VerifyPDFError.VERIFY_BYTE_RANGE,
-    );
+  if (!skipByteRangeVerification) {
+    if (pdfBuffer.length > endOfByteRange) {
+      throw new VerifyPDFError(
+        'Failed byte range verification.',
+        VerifyPDFError.VERIFY_BYTE_RANGE,
+      );
+    }
   }
 
   const signatureHex = pdfBuffer.slice(byteRange[0] + byteRange[1] + 1, byteRange[2]).toString('latin1');

--- a/lib/verifyPDF.js
+++ b/lib/verifyPDF.js
@@ -12,11 +12,15 @@ const {
 } = require('./helpers');
 const { extractCertificatesDetails } = require('./certificateDetails');
 
-module.exports = (pdf) => {
+module.exports = (pdf, { skipByteRangeVerification } = { skipByteRangeVerification: false }) => {
   const pdfBuffer = preparePDF(pdf);
   checkForSubFilter(pdfBuffer);
   try {
-    const { signature, signedData, signatureMeta } = extractSignature(pdfBuffer);
+    const {
+      signature,
+      signedData,
+      signatureMeta,
+    } = extractSignature(pdfBuffer, skipByteRangeVerification);
     const message = getMessageFromSignature(signature);
     const {
       certificates,

--- a/lib/verifyPDF.test.js
+++ b/lib/verifyPDF.test.js
@@ -72,6 +72,19 @@ describe('Test verification', () => {
 
     expect(valid).toBe(false);
   });
+  it('return { verified: true } if bytes are added to the end of the PDF but skipByteRangeVerification is passed', async () => {
+    const signedPdfBuffer = fs.readFileSync(getResourceAbsolutePath('samples/bytes-added.pdf'));
+    let valid;
+
+    try {
+      extractSignature(signedPdfBuffer, { skipByteRangeVerification: true });
+      valid = true;
+    } catch (e) {
+      valid = false;
+    }
+
+    expect(valid).toBe(true);
+  });
   it('return { verified: false } if signature is changed', async () => {
     const pdfBuffer = await createPDF();
     const p12Buffer = fs.readFileSync(getResourceAbsolutePath('certificate.p12'));


### PR DESCRIPTION
Until validating multiple signatures is added, this is a stopgap measure to allow the first certificate in a PDF to be verified.

While https://github.com/ninja-labs-tech/verify-pdf/issues/108 is correct, an individual ByteRange should cover to the end of the "file", a PDF can contain multiple ByteRanges, especially because a PDF can be modified by incremental update, and a 2nd ByteRange is added then to cover the modification. The original ByteRange only covers up to the `%%EOF` where the original file ended before modification.

The proper fix is to implement support for multiple signatures. I might be able to work on this but for now I need a stopgap to support my use case.